### PR TITLE
feat: Phase 1 — Orchestra IDE core model & TUI shell

### DIFF
--- a/ORCHESTRA_PLAN.md
+++ b/ORCHESTRA_PLAN.md
@@ -1,0 +1,275 @@
+# Orchestra IDE — Plan d'Architecture & Roadmap (Prototype CLI) v3.0
+
+> Document de préparation projet. Cible code : repo dédié `maximelarrieu/orchestra-ide`
+> (Rust / Tokio / ratatui). Ce document décrit la vision, l'architecture découplée et
+> la décomposition en **5 phases incrémentales** (MVP / structure de fichiers / code minimal).
+
+---
+
+## 1. Vision
+
+Moteur + interface d'un « IDE pour l'ère agentique » (**Orchestra**). Approche en deux temps :
+
+1. **Phase actuelle** : application Terminal (TUI) très visuelle — écran radar du flux
+   d'activité des agents, bordures ASCII, couleurs — via `ratatui` (+ `crossterm`).
+2. **Phase future** : portage vers une UI graphique (**Tauri + React**), d'où la
+   nécessité de **découpler strictement la logique métier de l'affichage**.
+
+Décisions actées :
+- **Repo cible** : `maximelarrieu/orchestra-ide` (dédié).
+- **Moteur TUI** : `ratatui`.
+- **Runtime** : `tokio`. **Communication agents ↔ UI** : `tokio::sync::mpsc`.
+
+---
+
+## 2. Maquette TUI cible
+
+```text
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ORCHESTRA IDE v1.0.0 | Espace actuel : [Recherche_Immo_Aix]                 │
+├────────────────────────────────────────────────────────────────────────────┤
+│ 🛰️  ÉCRAN RADAR (FLUX D'ACTIVITÉ DES AGENTS)                                 │
+│ ├─ 🤖 Agent_Scraper  -> Initialisation du scraping (LeBonCoin)               │
+│ ├─ 🤖 Agent_Scraper  -> 12 nouvelles annonces trouvées à Aix                 │
+│ ├─ 🤖 Agent_Filtrage -> Analyse via LLM...                                   │
+│ └─ 🤖 Agent_Filtrage -> ❌ 9 rejetées (Hors budget/critères)                 │
+├────────────────────────────────────────────────────────────────────────────┤
+│ 📋 OPTIONS & MENUS                                                           │
+│ [1] Lancer une intention   [2] Voir les ADRs   [3] Changer d'Espace          │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Architecture transverse — découplage strict (clé du futur port Tauri)
+
+**Workspace Cargo multi-crates** :
+
+```
+orchestra-ide/
+├─ Cargo.toml                 # [workspace] members = ["crates/*"]
+├─ crates/
+│  ├─ orchestra-core/         # lib — AUCUNE dépendance UI. Domaine pur.
+│  │  └─ src/
+│  │     ├─ lib.rs
+│  │     ├─ error.rs          # OrchestraError (thiserror)
+│  │     ├─ model/            # ContextSpace, ProjectConfig, ProjectType, Persona, Adr
+│  │     ├─ skills/           # trait Skill + registre + implémentations
+│  │     ├─ agents/           # trait Agent + Orchestrator
+│  │     ├─ events.rs         # AgentEvent — CONTRAT cœur ↔ UI
+│  │     └─ llm/              # trait LlmProvider (abstrait, mockable)
+│  └─ orchestra-tui/          # bin — ratatui. Consomme orchestra-core via events.
+│     └─ src/{main.rs, dashboard.rs, commands/}
+└─ (futur) crates/orchestra-tauri/   # réutilise orchestra-core tel quel
+```
+
+**Règle d'or appliquée** : le cœur n'écrit **jamais** sur stdout ; il publie des
+`AgentEvent` sur un canal `mpsc`. Le TUI (puis Tauri) est un simple *consommateur*.
+Le port graphique consiste alors à remplacer `orchestra-tui` sans toucher au cœur.
+
+**Dépendances clés** : `tokio`, `serde`/`serde_json`, `ratatui` + `crossterm`,
+`dialoguer`, `clap`, `thiserror`, `async-trait`, puis (phases 4-5) `git2`, `reqwest`.
+
+---
+
+## 4. Modèle de données « Espace de Contexte » (agnostique)
+
+Un espace = un dossier contenant `.orchestra/config.json` (+ `persona.md`, `adr/`).
+100 % modulable, 4 types de projet hors-dev/dev : **Dev, Nutrition, Langue, Immobilier**.
+
+`.orchestra/config.json` (agnostique, intégrations optionnelles) :
+
+```json
+{
+  "project_name": "SaaS Vétérinaire",
+  "project_type": "dev",
+  "workspace_path": "C:/Users/dev/projects/saas-vet",
+  "documentalist_enabled": true,
+  "agents": ["Agent_Architecte", "Agent_Dev", "Agent_Documentaliste"],
+  "skills": ["Read_File", "Write_File_Validated", "Execute_Terminal_Command"],
+  "integrations": {
+    "git":    { "auto_branching": true, "main_branch": "main" },
+    "github": { "repo": "github.com/mon-compte/saas-vet", "token_env_var": "ORCHESTRA_GITHUB_TOKEN" },
+    "jira":   { "project_key": "VET", "url": "https://mon-equipe.atlassian.net", "token_env_var": "ORCHESTRA_JIRA_TOKEN" }
+  }
+}
+```
+
+**Matrice Skills par défaut (spec §3)** :
+
+| Type | Skills par défaut |
+|------|-------------------|
+| Dev | `Read_File`, `Write_File_Validated` (guardrail `cargo check`), `Execute_Terminal_Command` |
+| Nutrition | `Web_Search`, `Calorie_Calculator`, `File_Append` |
+| Langue | `Generate_Quiz`, `Translate_Text`, `Text_To_Speech` |
+| Immobilier | `Scrape_Web_Page`, `Extract_JSON_From_HTML`, `Geocoding_Calcul` |
+
+---
+
+## 5. Décomposition en 5 phases incrémentales
+
+### PHASE 1 — Modèle des Espaces + coquille ASCII (sans LLM)
+
+**MVP** : charger un `.orchestra/config.json` en `ContextSpace` ; afficher le
+dashboard ratatui en 3 zones (en-tête / radar vide / menu) ; `q` quitte.
+
+**Fichiers** : `core/model/{project_type,config,space,skill_id}.rs`, `core/events.rs`,
+`core/error.rs` ; `tui/{main,dashboard}.rs`.
+
+**Code minimal (cœur)** :
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectType { Dev, Nutrition, Langue, Immobilier }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectConfig {
+    pub project_name: String,
+    pub project_type: ProjectType,
+    #[serde(default)] pub workspace_path: Option<PathBuf>,
+    #[serde(default)] pub documentalist_enabled: bool,
+    #[serde(default)] pub skills: Vec<String>,
+    #[serde(default)] pub agents: Vec<String>,
+    #[serde(default)] pub integrations: Integrations,
+}
+
+pub struct ContextSpace { pub root: PathBuf, pub config: ProjectConfig,
+                          pub persona: Option<String>, pub adrs: Vec<Adr> }
+impl ContextSpace {
+    pub fn load(root: &Path) -> Result<Self, OrchestraError> {
+        let cfg: ProjectConfig = serde_json::from_str(
+            &fs::read_to_string(root.join(".orchestra/config.json"))?)?;
+        Ok(Self { root: root.into(), config: cfg, persona: None, adrs: vec![] })
+    }
+}
+```
+
+**Code minimal (TUI)** :
+```rust
+let chunks = Layout::vertical([
+    Constraint::Length(3),   // en-tête
+    Constraint::Min(8),      // 🛰️ ÉCRAN RADAR (vide)
+    Constraint::Length(4),   // 📋 OPTIONS & MENUS
+]).split(area);
+frame.render_widget(Block::bordered().title(header), chunks[0]);
+frame.render_widget(Block::bordered().title("🛰️  ÉCRAN RADAR"), chunks[1]);
+frame.render_widget(Block::bordered().title("📋 OPTIONS & MENUS"), chunks[2]);
+```
+
+**Vérif** : `cargo run -p orchestra-tui` dans un dossier avec `.orchestra/config.json`
+exemple → 3 zones bordées, en-tête au nom de l'espace, radar vide, `q` restaure le terminal.
+
+---
+
+### PHASE 2 — Commande `orchestra init` (scaffolding) + templates par type
+
+**MVP** : `orchestra init` interactif (`dialoguer`) → nom, type (Dev/Langue/Immobilier/
+Nutrition), activation Documentaliste → génère `.orchestra/` + `.orchestra/adr/` +
+`persona.md` (templatisé par type) + `config.json` (matrice Skills/Agents) + ASCII art succès.
+
+**Fichiers** : `core/scaffold/{mod,templates}.rs` ; `tui/commands/init.rs` ;
+`tui/main.rs` (clap : `init` | `dashboard`).
+
+**Code minimal** (signature imposée par la spec) :
+```rust
+pub async fn run_init_command() -> Result<(), OrchestraError> {
+    let name = Input::new().with_prompt("Nom du projet").interact_text()?;
+    let kind = Select::new().items(&["Dev","Langue","Immobilier","Nutrition"]).interact()?;
+    let doc  = Confirm::new().with_prompt("Agent Documentaliste ?").interact()?;
+    let cfg  = ProjectConfig::default_for(kind.into(), &name, doc);
+    scaffold::write_space(&env::current_dir()?, &cfg)?;
+    print_success_ascii(&name);
+    Ok(())
+}
+```
+Template `persona.md` adapté (ex. Langue → demande niveau actuel + langue cible).
+
+**Vérif** : `orchestra init` dans un dossier vide → relire le `config.json` généré, puis
+`orchestra dashboard` charge l'espace créé.
+
+---
+
+### PHASE 3 — Runtime d'agents + flux temps réel (mpsc) → Radar vivant
+
+**MVP** : l'Orchestrateur lance les agents en tâches `tokio`, chacun publie des
+`AgentEvent` sur un `mpsc`. Le dashboard consomme le flux et fait défiler les lignes du
+Radar. Agents **simulés**, Skills mockés via trait + registre (toujours sans LLM).
+
+**Fichiers** : `core/agents/{mod,orchestrator,agent}.rs`, `core/skills/{mod,registry}.rs`,
+maj `tui/dashboard.rs` (état scrollable).
+
+**Code minimal** :
+```rust
+pub enum AgentEvent { Log { agent: String, msg: String }, Done { agent: String } }
+
+#[async_trait] pub trait Agent { async fn run(&self, tx: Sender<AgentEvent>); }
+#[async_trait] pub trait Skill { async fn execute(&self, input: Value)
+                                   -> Result<Value, OrchestraError>; }
+// orchestrator : for a in agents { let tx = tx.clone(); tokio::spawn(async move { a.run(tx).await }); }
+// tui boucle : select! { Some(ev) = rx.recv() => radar.push(ev), key = events.next() => handle(key) }
+```
+
+**Vérif** : lancer une « intention » depuis le menu → lignes qui apparaissent en direct
+dans le Radar sans bloquer le clavier.
+
+---
+
+### PHASE 4 — Intégration LLM + Skills écosystème Dev (Git / Jira / GitHub)
+
+**MVP** : brancher un `LlmProvider` réel (derrière trait → mockable/swappable). Implémenter
+les Skills Dev et câbler le **workflow JIRA-12** (spec §6.C).
+
+**Skills** : `Jira_Fetch_Ticket` (reqwest, token via `token_env_var`), `Git_Lifecycle`
+(`git2` : branche / commit / push), `GitHub_Open_PR` (API REST), `Write_File_Validated`
+(guardrail `cargo check`), `Execute_Terminal_Command`.
+
+**Workflow orchestré** :
+1. « Prends le ticket JIRA-12 et traite-le ».
+2. `Jira_Fetch_Ticket` → description + critères d'acceptation.
+3. Agent_Architecte planifie (ticket + fichiers locaux du `workspace_path`).
+4. `Git_Lifecycle(Create_Branch "feature/JIRA-12")`.
+5. Agent_Dev code/teste via `Write_File_Validated`.
+6. `Git_Lifecycle(Commit & Push)`.
+7. `GitHub_Open_PR` → lien affiché en ASCII dans le Radar.
+
+**Fichiers** : `core/llm/{mod,provider}.rs`, `core/skills/{git,jira,github,fs_validated,
+terminal}.rs`. Secrets lus via `*_env_var` (jamais en clair).
+
+**Vérif** : sur un repo Dev de test (tokens en env), dérouler jusqu'au lien de PR ;
+`Write_File_Validated` doit bloquer si `cargo check` échoue.
+
+---
+
+### PHASE 5 — Agent Documentaliste + finitions & validation du découplage
+
+**MVP** : agent `Documentaliste` déclenché **automatiquement** par l'Orchestrateur en fin
+de tâche dev réussie (code écrit/compilé/testé), **avant** le commit final.
+
+**Skills** : `Doc_Auto_Update` (MAJ intelligente des `.md` sans écraser l'existant) et
+`Mermaid_Schema_Generator` (ERD Mermaid depuis migrations / structs Rust). Structure
+maintenue dans le workspace : `docs/architecture/` (ADR), `docs/technical/` (Mermaid + API),
+`docs/functional/`.
+
+**Hook orchestrateur** :
+```text
+si config.documentalist_enabled et task.success :
+    Documentaliste(ticket, diff) -> écrit/MAJ docs/  -> puis Git_Lifecycle(Commit final)
+```
+
+**Finitions** : visualiseur d'ADR ([2]), changement d'Espace ([3]), et **test de
+découplage** : `orchestra-core` doit compiler sans aucune dépendance UI (preuve que le
+port Tauri est faisable).
+
+**Fichiers** : `core/agents/documentalist.rs`, `core/skills/{doc_update,mermaid}.rs`,
+`tui/views/{adr,space_switch}.rs`.
+
+**Vérif** : tâche dev complète avec Documentaliste activé → `docs/` peuplé/mis à jour,
+ADR consultable dans la TUI, diagramme Mermaid valide, commit final incluant la doc.
+
+---
+
+## 6. Étapes d'exécution (au signal « go Phase 1 »)
+
+1. Ajouter `maximelarrieu/orchestra-ide` au scope de session (`add_repo`), vérifier s'il est vide.
+2. Brancher, scaffolder le workspace Cargo (crates `orchestra-core` + `orchestra-tui`).
+3. Implémenter **uniquement la Phase 1**, puis s'arrêter (règle stricte de la spec).

--- a/orchestra-ide/.gitignore
+++ b/orchestra-ide/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/orchestra-ide/Cargo.toml
+++ b/orchestra-ide/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+resolver = "2"
+members = ["crates/orchestra-core", "crates/orchestra-tui"]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+ratatui = "0.29"

--- a/orchestra-ide/README.md
+++ b/orchestra-ide/README.md
@@ -1,0 +1,40 @@
+# Orchestra IDE — Prototype CLI (Rust)
+
+Moteur + interface d'un « IDE pour l'ère agentique ». TUI aujourd'hui (`ratatui`),
+portage Tauri + React prévu — d'où le **découplage strict** logique métier / affichage.
+
+> Plan d'architecture complet (5 phases) : voir `../ORCHESTRA_PLAN.md`.
+> Ce dossier sera recopié à terme dans le repo dédié `maximelarrieu/orchestra-ide`.
+
+## Structure (workspace Cargo)
+
+```
+crates/
+├─ orchestra-core/   # domaine pur — AUCUNE dépendance UI
+│  └─ src/{error,events,model/{project_type,config,space,skill_id}}.rs
+└─ orchestra-tui/    # frontend ratatui — consomme orchestra-core
+   └─ src/{main,dashboard}.rs
+```
+
+## Phase 1 (actuelle)
+
+Modèle des Espaces de Contexte agnostiques + coquille ASCII du dashboard (3 zones :
+en-tête / écran radar / menu). **Sans LLM, sans agent** : le radar est vide.
+
+### Lancer
+
+```bash
+# Ouvre l'espace exemple fourni
+cargo run -p orchestra-tui -- examples/recherche-immo-aix
+# Quitter : q ou Échap
+```
+
+Sans argument, l'outil tente de charger un `.orchestra/config.json` du répertoire courant ;
+s'il n'en trouve pas, le dashboard s'affiche en état « Aucun espace chargé ».
+
+## Phases suivantes
+
+2. Commande `orchestra init` (scaffolding interactif).
+3. Runtime d'agents + flux temps réel (`tokio::sync::mpsc`) → radar vivant.
+4. Intégration LLM + Skills écosystème Dev (Git / Jira / GitHub).
+5. Agent Documentaliste (Doc_Auto_Update, Mermaid) + finitions.

--- a/orchestra-ide/crates/orchestra-core/Cargo.toml
+++ b/orchestra-ide/crates/orchestra-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "orchestra-core"
+description = "Cœur métier d'Orchestra IDE — aucune dépendance UI (port Tauri futur)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/orchestra-ide/crates/orchestra-core/src/error.rs
+++ b/orchestra-ide/crates/orchestra-core/src/error.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Erreur unique du cœur d'Orchestra. Les couches supérieures (CLI, futurs agents)
+/// remontent toutes leurs erreurs via ce type.
+#[derive(Debug, Error)]
+pub enum OrchestraError {
+    #[error("Espace introuvable : impossible de lire {path} ({source})")]
+    SpaceNotFound {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Configuration invalide : {0}")]
+    InvalidConfig(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/orchestra-ide/crates/orchestra-core/src/events.rs
+++ b/orchestra-ide/crates/orchestra-core/src/events.rs
@@ -1,0 +1,14 @@
+//! Contrat d'événements cœur ↔ UI.
+//!
+//! En Phase 1 ce type est défini mais pas encore émis : les agents qui le publieront
+//! sur un canal `tokio::sync::mpsc` arrivent en Phase 3. Le figer dès maintenant fixe
+//! l'interface que le TUI — puis l'UI Tauri — consommera sans connaître le cœur.
+
+/// Une unité d'activité observable sur l'« écran radar ».
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    /// Ligne de log d'un agent (ex. « 12 nouvelles annonces trouvées »).
+    Log { agent: String, msg: String },
+    /// L'agent a terminé sa tâche.
+    Done { agent: String },
+}

--- a/orchestra-ide/crates/orchestra-core/src/lib.rs
+++ b/orchestra-ide/crates/orchestra-core/src/lib.rs
@@ -1,0 +1,12 @@
+//! Cœur métier d'Orchestra IDE.
+//!
+//! Ce crate ne dépend d'AUCUNE bibliothèque d'affichage : il expose le modèle des
+//! « Espaces de Contexte », les erreurs et le contrat d'événements ([`events::AgentEvent`])
+//! que l'UI (ratatui aujourd'hui, Tauri demain) consomme. C'est la garantie du
+//! découplage strict logique métier / affichage exigé par la spec.
+
+pub mod error;
+pub mod events;
+pub mod model;
+
+pub use error::OrchestraError;

--- a/orchestra-ide/crates/orchestra-core/src/model/config.rs
+++ b/orchestra-ide/crates/orchestra-core/src/model/config.rs
@@ -1,0 +1,95 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::project_type::ProjectType;
+
+/// Contenu de `.orchestra/config.json` : la définition complète d'un Espace de Contexte.
+///
+/// Volontairement agnostique — un projet Dev, Nutrition, Langue ou Immobilier partage
+/// la même structure ; seuls les Skills/Agents et les intégrations diffèrent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectConfig {
+    pub project_name: String,
+    pub project_type: ProjectType,
+
+    /// Chemin local ciblé (projets « Dev »). `None` pour les projets hors-dev.
+    #[serde(default)]
+    pub workspace_path: Option<PathBuf>,
+
+    /// Active l'Agent Documentaliste (Phase 5).
+    #[serde(default)]
+    pub documentalist_enabled: bool,
+
+    /// Identifiants des Skills activés (exécutables en Phase 3).
+    #[serde(default)]
+    pub skills: Vec<String>,
+
+    /// Noms des agents composant l'orchestre.
+    #[serde(default)]
+    pub agents: Vec<String>,
+
+    /// Intégrations écosystème (Phase 4) — toutes optionnelles.
+    #[serde(default)]
+    pub integrations: Integrations,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Integrations {
+    #[serde(default)]
+    pub git: Option<GitIntegration>,
+    #[serde(default)]
+    pub github: Option<GithubIntegration>,
+    #[serde(default)]
+    pub jira: Option<JiraIntegration>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitIntegration {
+    #[serde(default)]
+    pub auto_branching: bool,
+    pub main_branch: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubIntegration {
+    pub repo: String,
+    /// Nom de la variable d'environnement contenant le token (jamais le token en clair).
+    pub token_env_var: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JiraIntegration {
+    pub project_key: String,
+    pub url: String,
+    pub token_env_var: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_immobilier_space() {
+        let raw = r#"{
+            "project_name": "Recherche_Immo_Aix",
+            "project_type": "immobilier",
+            "agents": ["Agent_Scraper", "Agent_Filtrage"],
+            "skills": ["Scrape_Web_Page", "Extract_JSON_From_HTML", "Geocoding_Calcul"]
+        }"#;
+
+        let cfg: ProjectConfig = serde_json::from_str(raw).expect("config valide");
+        assert_eq!(cfg.project_type, ProjectType::Immobilier);
+        assert_eq!(cfg.skills.len(), 3);
+        // Champs absents → valeurs par défaut (serde(default)).
+        assert!(cfg.workspace_path.is_none());
+        assert!(!cfg.documentalist_enabled);
+        assert!(cfg.integrations.git.is_none());
+    }
+
+    #[test]
+    fn project_type_round_trips_snake_case() {
+        let json = serde_json::to_string(&ProjectType::Dev).unwrap();
+        assert_eq!(json, "\"dev\"");
+    }
+}

--- a/orchestra-ide/crates/orchestra-core/src/model/mod.rs
+++ b/orchestra-ide/crates/orchestra-core/src/model/mod.rs
@@ -1,0 +1,11 @@
+//! Modèle de données agnostique des « Espaces de Contexte ».
+
+pub mod config;
+pub mod project_type;
+pub mod skill_id;
+pub mod space;
+
+pub use config::{GitIntegration, GithubIntegration, Integrations, JiraIntegration, ProjectConfig};
+pub use project_type::ProjectType;
+pub use skill_id::default_skills;
+pub use space::{Adr, ContextSpace};

--- a/orchestra-ide/crates/orchestra-core/src/model/project_type.rs
+++ b/orchestra-ide/crates/orchestra-core/src/model/project_type.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+/// Les quatre familles de projets que l'outil sait modéliser nativement.
+///
+/// Le type pilote la matrice de Skills/Agents par défaut (voir [`super::skill_id`])
+/// et les templates générés par `orchestra init` (Phase 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectType {
+    Dev,
+    Nutrition,
+    Langue,
+    Immobilier,
+}
+
+impl ProjectType {
+    /// Libellé court pour l'affichage.
+    pub fn label(self) -> &'static str {
+        match self {
+            ProjectType::Dev => "Dev",
+            ProjectType::Nutrition => "Nutrition",
+            ProjectType::Langue => "Langue",
+            ProjectType::Immobilier => "Immobilier",
+        }
+    }
+}

--- a/orchestra-ide/crates/orchestra-core/src/model/skill_id.rs
+++ b/orchestra-ide/crates/orchestra-core/src/model/skill_id.rs
@@ -1,0 +1,18 @@
+use super::project_type::ProjectType;
+
+/// Matrice des Skills activés par défaut selon le type de projet (spec §3).
+///
+/// Utilisée par `orchestra init` (Phase 2) pour pré-remplir `config.json`. Les Skills
+/// sont pour l'instant des identifiants (`String`) ; le trait `Skill` exécutable arrive
+/// en Phase 3.
+pub fn default_skills(kind: ProjectType) -> Vec<String> {
+    let skills: &[&str] = match kind {
+        ProjectType::Dev => &["Read_File", "Write_File_Validated", "Execute_Terminal_Command"],
+        ProjectType::Nutrition => &["Web_Search", "Calorie_Calculator", "File_Append"],
+        ProjectType::Langue => &["Generate_Quiz", "Translate_Text", "Text_To_Speech"],
+        ProjectType::Immobilier => {
+            &["Scrape_Web_Page", "Extract_JSON_From_HTML", "Geocoding_Calcul"]
+        }
+    };
+    skills.iter().map(|s| s.to_string()).collect()
+}

--- a/orchestra-ide/crates/orchestra-core/src/model/space.rs
+++ b/orchestra-ide/crates/orchestra-core/src/model/space.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::OrchestraError;
+
+use super::config::ProjectConfig;
+
+/// Un Architecture Decision Record référencé dans l'espace.
+#[derive(Debug, Clone)]
+pub struct Adr {
+    pub title: String,
+    pub path: PathBuf,
+}
+
+/// Un Espace de Contexte chargé en mémoire : configuration + persona + ADRs.
+///
+/// Point d'entrée du cœur. L'UI ne manipule que cette structure (et les événements),
+/// jamais le système de fichiers directement.
+#[derive(Debug, Clone)]
+pub struct ContextSpace {
+    pub root: PathBuf,
+    pub config: ProjectConfig,
+    pub persona: Option<String>,
+    pub adrs: Vec<Adr>,
+}
+
+impl ContextSpace {
+    /// Charge l'espace situé dans `root` (qui doit contenir `.orchestra/config.json`).
+    pub fn load(root: &Path) -> Result<Self, OrchestraError> {
+        let config_path = root.join(".orchestra").join("config.json");
+        let raw = fs::read_to_string(&config_path).map_err(|source| {
+            OrchestraError::SpaceNotFound {
+                path: config_path.clone(),
+                source,
+            }
+        })?;
+        let config: ProjectConfig = serde_json::from_str(&raw)?;
+
+        let persona = fs::read_to_string(root.join(".orchestra").join("persona.md")).ok();
+        let adrs = Self::load_adrs(&root.join(".orchestra").join("adr"));
+
+        Ok(Self {
+            root: root.to_path_buf(),
+            config,
+            persona,
+            adrs,
+        })
+    }
+
+    fn load_adrs(dir: &Path) -> Vec<Adr> {
+        let mut adrs = Vec::new();
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                    let title = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("ADR")
+                        .to_string();
+                    adrs.push(Adr { title, path });
+                }
+            }
+        }
+        adrs.sort_by(|a, b| a.title.cmp(&b.title));
+        adrs
+    }
+}

--- a/orchestra-ide/crates/orchestra-tui/Cargo.toml
+++ b/orchestra-ide/crates/orchestra-tui/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "orchestra-tui"
+description = "Frontend terminal (ratatui) d'Orchestra IDE — consomme orchestra-core."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "orchestra"
+path = "src/main.rs"
+
+[dependencies]
+orchestra-core = { path = "../orchestra-core" }
+ratatui = { workspace = true }

--- a/orchestra-ide/crates/orchestra-tui/src/dashboard.rs
+++ b/orchestra-ide/crates/orchestra-tui/src/dashboard.rs
@@ -1,0 +1,64 @@
+//! Rendu de la coquille du tableau de bord.
+//!
+//! Trois zones empilées reproduisant la maquette de la spec : en-tête, écran radar
+//! (vide en Phase 1) et menu d'options.
+
+use orchestra_core::model::ContextSpace;
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Style, Stylize};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+
+pub fn render(frame: &mut Frame, space: Option<&ContextSpace>) {
+    let [header, radar, menu] = Layout::vertical([
+        Constraint::Length(3), // en-tête
+        Constraint::Min(8),    // écran radar
+        Constraint::Length(4), // menu
+    ])
+    .areas(frame.area());
+
+    render_header(frame, header, space);
+    render_radar(frame, radar);
+    render_menu(frame, menu);
+}
+
+fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, space: Option<&ContextSpace>) {
+    let (name, kind) = match space {
+        Some(s) => (
+            s.config.project_name.clone(),
+            s.config.project_type.label(),
+        ),
+        None => ("Aucun espace chargé".to_string(), "—"),
+    };
+
+    let line = Line::from(vec![
+        Span::styled("ORCHESTRA IDE v0.1.0", Style::new().bold().cyan()),
+        Span::raw("  |  Espace actuel : "),
+        Span::styled(format!("[{name}]"), Style::new().yellow().bold()),
+        Span::raw(format!("  ({kind})")),
+    ]);
+
+    frame.render_widget(Paragraph::new(line).block(Block::bordered()), area);
+}
+
+fn render_radar(frame: &mut Frame, area: ratatui::layout::Rect) {
+    let block = Block::bordered().title(" 🛰  ÉCRAN RADAR (FLUX D'ACTIVITÉ DES AGENTS) ");
+    let body = Paragraph::new(vec![
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  En attente d'activité… (aucun agent branché — Phase 1)",
+            Style::new().dark_gray(),
+        )),
+    ])
+    .block(block);
+    frame.render_widget(body, area);
+}
+
+fn render_menu(frame: &mut Frame, area: ratatui::layout::Rect) {
+    let block = Block::bordered().title(" 📋 OPTIONS & MENUS ");
+    let line = Line::from(
+        "[1] Lancer une intention   [2] Voir les ADRs   [3] Changer d'Espace   [q] Quitter",
+    );
+    frame.render_widget(Paragraph::new(line).block(block), area);
+}

--- a/orchestra-ide/crates/orchestra-tui/src/main.rs
+++ b/orchestra-ide/crates/orchestra-tui/src/main.rs
@@ -1,0 +1,45 @@
+//! Frontend terminal d'Orchestra IDE (Phase 1).
+//!
+//! Affiche la coquille du tableau de bord en 3 zones (en-tête / écran radar / menu).
+//! Aucun LLM, aucun agent : le radar est vide. Le code ne fait que charger un Espace
+//! de Contexte via `orchestra-core` et le rendre.
+
+mod dashboard;
+
+use std::path::PathBuf;
+
+use orchestra_core::model::ContextSpace;
+use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::DefaultTerminal;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // L'espace à ouvrir : 1er argument CLI, sinon le répertoire courant.
+    let root = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // On tolère l'absence d'espace : le dashboard s'affiche quand même (état « vide »).
+    let space = ContextSpace::load(&root).ok();
+
+    let mut terminal = ratatui::init();
+    let result = run(&mut terminal, space);
+    ratatui::restore();
+    result
+}
+
+fn run(
+    terminal: &mut DefaultTerminal,
+    space: Option<ContextSpace>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        terminal.draw(|frame| dashboard::render(frame, space.as_ref()))?;
+
+        if let Event::Key(key) = event::read()? {
+            if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/orchestra-ide/examples/recherche-immo-aix/.orchestra/config.json
+++ b/orchestra-ide/examples/recherche-immo-aix/.orchestra/config.json
@@ -1,0 +1,9 @@
+{
+  "project_name": "Recherche_Immo_Aix",
+  "project_type": "immobilier",
+  "workspace_path": null,
+  "documentalist_enabled": false,
+  "agents": ["Agent_Scraper", "Agent_Filtrage"],
+  "skills": ["Scrape_Web_Page", "Extract_JSON_From_HTML", "Geocoding_Calcul"],
+  "integrations": {}
+}

--- a/orchestra-ide/examples/recherche-immo-aix/.orchestra/persona.md
+++ b/orchestra-ide/examples/recherche-immo-aix/.orchestra/persona.md
@@ -1,0 +1,10 @@
+# Persona — Recherche immobilière (Aix-en-Provence)
+
+## Critères stricts
+- **Budget max** : à compléter
+- **Surface min (m²)** : à compléter
+- **Quartiers cibles** : à compléter
+- **Diagnostics minimum (DPE)** : à compléter
+
+## Sources
+- LeBonCoin, SeLoger


### PR DESCRIPTION
## Summary

Initial implementation of Orchestra IDE Phase 1: a decoupled architecture for an agent-based IDE with a terminal UI. This establishes the foundational model layer (`orchestra-core`) and a minimal ratatui-based dashboard (`orchestra-tui`), with strict separation between domain logic and presentation.

## Key Changes

- **Workspace structure**: Multi-crate Cargo workspace with `orchestra-core` (domain logic, zero UI dependencies) and `orchestra-tui` (ratatui frontend)

- **Core domain model** (`orchestra-core`):
  - `ProjectType` enum: Dev, Nutrition, Langue, Immobilier
  - `ProjectConfig`: JSON-serializable configuration structure with optional integrations (Git, GitHub, Jira)
  - `ContextSpace`: In-memory representation of a project space (loads `.orchestra/config.json`, persona, ADRs)
  - `AgentEvent`: Event contract for agent→UI communication (Log, Done)
  - `OrchestraError`: Unified error type using `thiserror`
  - `default_skills()`: Skill matrix by project type

- **TUI dashboard** (`orchestra-tui`):
  - Three-zone layout: header (project info), radar (empty in Phase 1), menu
  - Renders loaded `ContextSpace` or graceful "no space loaded" state
  - Keyboard handling: `q` or Esc to quit
  - Accepts optional CLI argument for space root path

- **Example space**: `examples/recherche-immo-aix/` with sample Immobilier project config and persona

- **Documentation**: Comprehensive `ORCHESTRA_PLAN.md` detailing 5-phase roadmap, architecture decisions, and implementation strategy

## Notable Implementation Details

- **Strict decoupling**: `orchestra-core` has zero dependencies on `ratatui`, `crossterm`, or any UI library—enabling future Tauri port without core changes
- **Graceful degradation**: TUI runs even without a valid space (displays "Aucun espace chargé")
- **Serde defaults**: Config fields use `#[serde(default)]` for forward compatibility
- **Test coverage**: Unit tests for config parsing and ProjectType serialization

https://claude.ai/code/session_016BPjxVTfpiZ8tXmsHqPqvP